### PR TITLE
Fix `Song#create` with embedded code 

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -8,7 +8,7 @@ class Song < ApplicationRecord
 
   validates :title, presence: true
 
-  has_many :recordings, -> { order :created_at }
+  has_many :recordings, -> { order :created_at }, inverse_of: :song, dependent: :destroy
   accepts_nested_attributes_for :recordings, reject_if: proc { |attributes|
     attributes["url"].blank? && attributes["embedded_player"].blank?
   }, allow_destroy: true

--- a/spec/system/admin/songs_spec.rb
+++ b/spec/system/admin/songs_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe "As an admin user" do
   let(:title) { FFaker::Music.song }
   let(:chord_form) { chord_forms(:Am7) }
   let(:song) { songs(:hotel_california) }
+  let(:embed_code) { "https://www.youtube.com/watch?v=123456789" }
 
   before do
     login_as user
@@ -12,15 +13,16 @@ RSpec.describe "As an admin user" do
     visit admin_songs_path
     click_on "New Song"
     fill_in "Title", with: title
-
     attach_file "Image", Rails.root.join("spec/fixtures/files/image.jpeg")
-
     click_on "Add new chord form"
-
     select chord_form.chord
+
+    click_on "Add New Recording"
+    fill_in "Embedded player*", with: embed_code
+
     click_on "Create Song"
-    expect(find("img")["src"]).to eq Song.find_by(title: title).image_url(:thumb)
     expect(page).to have_content "Song was successfully created."
+    expect(find("img")["src"]).to eq Song.find_by(title: title).image_url(:thumb)
     expect(page).to have_content chord_form.chord
     expect(page).to have_css "div.chord-form svg"
   end


### PR DESCRIPTION
Song create was failing silently - just reloading the form - because of an issue with the relationship between `Recordings` and `Songs`. This would have been easy to spot if ActiveAdmin (the framework we use for the whole admin area) had printed the error to the screen, but it did not. 
I've fixed the error now.
Adding the `inverse_of` to get past ActiveAdmin errors on the nested form.