### PR TITLE
Switch to Mise and upgrade dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   heroku: circleci/heroku@2.0.0
   node: circleci/node@7.1.0
-  ruby: circleci/ruby@2.5.0
+  ruby: circleci/ruby@2.6.0
   browser-tools: circleci/browser-tools@1.5.2
 
 commands:
@@ -19,7 +19,7 @@ commands:
             - yarn-deps-v1-{{ checksum "yarn.lock" }}
             - yarn-deps-v1-
       - node/install:
-          node-version: 23.8.0
+          node-version: 25.2.1
       - node/install-packages:
           pkg-manager: yarn
       - run:
@@ -58,7 +58,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.4.1-browsers
+      - image: cimg/ruby:3.4.7-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.4.1
-nodejs 23.8.0
+ruby 3.4.7
+nodejs 25.2.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.4.1"
+ruby "3.4.7"
 
 gem "aws-sdk-s3", "~> 1.180"
 gem "activeadmin", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,7 +584,7 @@ DEPENDENCIES
   web-console (~> 4.2)
 
 RUBY VERSION
-   ruby 3.4.1p0
+  ruby 3.4.7p58
 
 BUNDLED WITH
-   2.5.7
+  4.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "25.x"
+  },
   "devDependencies": {
     "vite": "^7.2.7",
     "vite-plugin-ruby": "^5.1.0"


### PR DESCRIPTION
We needed a nodejs bump. When I went to also bump ruby I had yet another problem with asdf's ruby plug-in, so I'm switching locally to [mise](https://mise.jdx.dev/) and bumping both ruby and nodejs.