### PR TITLE
Surface recording URL in admin

### DIFF
--- a/app/admin/recordings.rb
+++ b/app/admin/recordings.rb
@@ -1,0 +1,66 @@
+ActiveAdmin.register Recording do
+  permit_params :title, :url, :embedded_player, :description, :reported, :song_id, :position
+
+  filter :title
+  filter :url
+  filter :description
+  filter :reported, as: :boolean
+  filter :song_title_cont, label: "Song Title"
+  filter :created_at
+  filter :updated_at
+
+  index do
+    column :title, sortable: true
+    column :song, sortable: 'songs.title' do |recording|
+      link_to recording.song.title, admin_song_path(recording.song) if recording.song
+    end
+    column :url do |recording|
+      link_to recording.url, recording.url, target: '_blank', rel: 'noopener' if recording.url.present?
+    end
+    column :reported, sortable: true
+    column :position, sortable: true
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :song, collection: Song.order(:title).map { |s| [s.title, s.id] },
+                     input_html: { class: 'tom-select' }
+      f.input :title
+      f.input :url
+      f.input :embedded_player, input_html: { rows: 5 }
+      f.input :description, input_html: { rows: 5 }
+      f.input :position
+      f.input :reported
+    end
+    f.actions
+  end
+
+  show do
+    attributes_table do
+      row :song do |recording|
+        link_to recording.song.title, admin_song_path(recording.song) if recording.song
+      end
+      row :title
+      row :url do |recording|
+        link_to recording.url, recording.url, target: '_blank', rel: 'noopener' if recording.url.present?
+      end
+      row :embedded_player do |recording|
+        raw recording.embedded_player if recording.embedded_player.present?
+      end
+      row :description do
+        simple_format recording.description
+      end
+      row :position
+      row :reported
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  controller do
+    def scoped_collection
+      super.joins(:song)
+    end
+  end
+end

--- a/app/admin/songs.rb
+++ b/app/admin/songs.rb
@@ -14,6 +14,7 @@ ActiveAdmin.register Song do
   filter :description
   filter :slug
   filter :recordings_reported, as: :boolean, label: "Broken Link Reported"
+  filter :recordings_url_present, label: "Has Recording URL", as: :boolean
 
   # Controller customization
   controller do

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -10,4 +10,8 @@ class Recording < ApplicationRecord
     %w[created_at description embedded_player id position reported song_id
        title updated_at url]
   end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[song]
+  end
 end

--- a/spec/system/admin/recordings_spec.rb
+++ b/spec/system/admin/recordings_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "Admin Recordings", type: :system do
+  let(:user) { users(:admin) }
+  let(:recording) { recordings(:hotel_california_soundclound) }
+  let(:song) { songs(:hotel_california) }
+
+  before do
+    login_as user
+  end
+
+  scenario "I can view the recordings index page" do
+    visit admin_recordings_path
+
+    expect(page).to have_content recording.title
+    expect(page).to have_link recording.url, href: recording.url
+    expect(page).to have_link song.title, href: admin_song_path(song)
+  end
+
+  scenario "I can view a recording show page" do
+    visit admin_recording_path(recording)
+
+    expect(page).to have_content recording.title
+    expect(page).to have_link recording.url, href: recording.url
+    expect(page).to have_link song.title, href: admin_song_path(song)
+    expect(page).to have_content recording.description if recording.description.present?
+  end
+end


### PR DESCRIPTION
We want to start updating our recordings with the raw audio source location so we can present then with a standardized player, as oppose letting the user add embedded player html.
This surfaces the recordings in the admin area so we can see where we're at.