### PR TITLE
Add featured songs to admin interface

### DIFF
--- a/app/admin/songs.rb
+++ b/app/admin/songs.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register Song do
   filter :slug
   filter :recordings_reported, as: :boolean, label: "Broken Link Reported"
   filter :recordings_url_present, label: "Has Recording URL", as: :boolean
-
+  filter :featured, as: :boolean
   # Controller customization
   controller do
     def find_resource
@@ -35,6 +35,7 @@ ActiveAdmin.register Song do
                 :description, :lyrics, :title, :translation,
                 :chords, :remove_image,
                 :composer_id,
+                :featured,
                 recordings_attributes: %i[
                   description
                   embedded_player
@@ -67,6 +68,9 @@ ActiveAdmin.register Song do
         end
       end
     end
+    column :featured, sortable: :featured do |song|
+      song.featured ? "Yes" : "No"
+    end
     column "Has Chords", sortable: :chords do |song|
       song.chords.present? ? "Yes" : "No"
     end
@@ -90,6 +94,7 @@ ActiveAdmin.register Song do
       f.input :remove_image, as: :boolean
       f.input :title
       f.input :alternate_title
+      f.input :featured, as: :boolean
       f.inputs "Composer" do
         f.input :composer_id, as: :select,
                               collection: Composer.order(:name).map { |c| [[c.name, c.url].reject(&:blank?).join(" | "), c.id] },
@@ -236,6 +241,9 @@ ActiveAdmin.register Song do
       end
       row :description do
         simple_format song.description
+      end
+      row :featured do |song|
+        song.featured ? "Yes" : "No"
       end
       row :lyrics do
         simple_format song.lyrics, {}, sanitize: false

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -33,7 +33,7 @@ class Song < ApplicationRecord
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[image_data alternate_title chords created_at description id
-       id_value image_data lyrics slug title translation updated_at]
+       id_value image_data lyrics slug title translation updated_at featured]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/db/migrate/20260115224724_add_featured_to_songs.rb
+++ b/db/migrate/20260115224724_add_featured_to_songs.rb
@@ -1,0 +1,7 @@
+class AddFeaturedToSongs < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+  def change
+    add_column :songs, :featured, :boolean, null: false, default: false
+    add_index :songs, :featured, where: 'featured', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_30_131457) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_15_224724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -143,6 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_30_131457) do
     t.string "composer_url"
     t.datetime "created_at", precision: nil, null: false
     t.text "description"
+    t.boolean "featured", default: false, null: false
     t.text "image_data"
     t.text "lyrics"
     t.string "slug"
@@ -150,6 +151,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_30_131457) do
     t.text "translation"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["composer_id"], name: "index_songs_on_composer_id"
+    t.index ["featured"], name: "index_songs_on_featured", where: "featured"
     t.index ["slug"], name: "index_songs_on_slug", unique: true
   end
 

--- a/spec/system/admin/songs/manage_songs_spec.rb
+++ b/spec/system/admin/songs/manage_songs_spec.rb
@@ -43,4 +43,19 @@ RSpec.describe "As an admin user" do
     expect(page).to have_content "Song was successfully updated."
     expect(song.reload.title).to eq "New Title"
   end
+
+  scenario "I can mark a song as featured", :focus do
+    visit edit_admin_song_path(song)
+    check "Featured"
+    click_on "Update Song"
+    expect(page).to have_content "Song was successfully updated."
+    expect(song.reload.featured).to be true
+    visit admin_songs_path
+    select "Yes", from: "Featured"
+    click_on "Filter"
+    expect(page).to have_content song.title
+    select "No", from: "Featured"
+    click_on "Filter"
+    expect(page).to have_no_content song.title
+  end
 end


### PR DESCRIPTION
Add a "featured" boolean flag to `Song` to support a rotating hero on the home page.

Closes #273 