### PR TITLE
Add cookie consent banner and use YouTube nocookie embeds

### DIFF
--- a/app/frontend/js/controllers/cookie_consent_controller.js
+++ b/app/frontend/js/controllers/cookie_consent_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus";
+
+const STORAGE_KEY = "cookie_consent";
+
+export default class extends Controller {
+  static targets = ["banner"];
+
+  connect() {
+    const consent = localStorage.getItem(STORAGE_KEY);
+    if (consent) {
+      this.bannerTarget.hidden = true;
+      if (consent === "accepted") this.loadAnalytics();
+    } else {
+      this.bannerTarget.hidden = false;
+    }
+  }
+
+  accept() {
+    localStorage.setItem(STORAGE_KEY, "accepted");
+    this.hideBanner();
+    this.loadAnalytics();
+  }
+
+  decline() {
+    localStorage.setItem(STORAGE_KEY, "declined");
+    this.hideBanner();
+  }
+
+  hideBanner() {
+    this.bannerTarget.hidden = true;
+    document.body.focus();
+  }
+
+  loadAnalytics() {
+    if (window.gtag || document.querySelector('script[src*="googletagmanager"]'))
+      return;
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src =
+      "https://www.googletagmanager.com/gtag/js?id=UA-134757294-1";
+    document.head.appendChild(script);
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function () {
+      window.dataLayer.push(arguments);
+    };
+    window.gtag("js", new Date());
+    window.gtag("config", "UA-134757294-1");
+  }
+}

--- a/app/frontend/scss/_layout.scss
+++ b/app/frontend/scss/_layout.scss
@@ -1,3 +1,4 @@
 @use "layout/grid" as *;
 @use "layout/header" as *;
 @use "layout/footer" as *;
+@use "layout/cookie_consent" as *;

--- a/app/frontend/scss/layout/_cookie_consent.scss
+++ b/app/frontend/scss/layout/_cookie_consent.scss
@@ -1,0 +1,56 @@
+@layer layout {
+  .cookie-consent {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: var(--color-midnight-teal);
+    outline: none;
+    border-top: 1px solid var(--color-aged-copper);
+    padding: 20px 0;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
+
+    .theme-light & {
+      background: var(--color-daybreak-linen);
+      border-top-color: var(--color-aged-copper);
+      box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  .cookie-consent__inner {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+
+    @media (max-width: 991.98px) {
+      flex-direction: column;
+      text-align: center;
+      gap: 16px;
+    }
+  }
+
+  .cookie-consent__text {
+    flex: 1;
+    font-family: var(--body-font-family);
+    font-size: 16px;
+    line-height: 1.5;
+    margin: 0;
+    color: var(--color-warm-stone);
+
+    .theme-light & {
+      color: var(--color-temple-charcoal);
+    }
+  }
+
+  .cookie-consent__actions {
+    display: flex;
+    gap: 12px;
+    flex-shrink: 0;
+
+    @media (max-width: 991.98px) {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+}

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -58,7 +58,7 @@ class Recording < ApplicationRecord
       match = external_media_url.match(%r{youtube\.com/watch\?v=([\w-]+)})
       return external_media_url unless match
 
-      "https://www.youtube.com/embed/#{match[1]}"
+      "https://www.youtube-nocookie.com/embed/#{match[1]}"
     end
 
     def format_soundcloud_url

--- a/app/views/layouts/_cookie_consent.html.haml
+++ b/app/views/layouts/_cookie_consent.html.haml
@@ -1,0 +1,9 @@
+.cookie-consent{ data: { controller: "cookie-consent", cookie_consent_target: "banner" }, role: "dialog", "aria-label" => "Cookie consent", "aria-describedby" => "cookie-consent-message", hidden: true, tabindex: "-1" }
+  .cookie-consent__inner.container
+    %p#cookie-consent-message.cookie-consent__text
+      We use cookies to understand how visitors use this site. Embedded media
+      players from third-party services may also set cookies for playback
+      functionality. By accepting, you allow analytics cookies.
+    .cookie-consent__actions
+      %button.btn{ data: { action: "cookie-consent#accept" }, type: "button" } Accept All
+      %button.btn.btn--secondary{ data: { action: "cookie-consent#decline" }, type: "button" } Necessary Only

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    = render 'layouts/google_analytics'
+    -# Google Analytics is loaded dynamically by the cookie consent controller
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}/
     %title Medicine Songs
@@ -42,6 +42,7 @@
     = yield
 
     = render 'layouts/footer'
-    
+    = render 'layouts/cookie_consent'
+
     -# Swiper JS
     %script{src: "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"}

--- a/spec/models/recording_spec.rb
+++ b/spec/models/recording_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Recording do
       let(:external_media_url) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
 
       it "returns the embed URL" do
-        expect(recording.formatted_external_media_url).to eq("https://www.youtube.com/embed/dQw4w9WgXcQ")
+        expect(recording.formatted_external_media_url).to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
       end
     end
 
@@ -112,7 +112,7 @@ RSpec.describe Recording do
       let(:external_media_url) { "https://youtube.com/watch?v=dQw4w9WgXcQ" }
 
       it "returns the embed URL" do
-        expect(recording.formatted_external_media_url).to eq("https://www.youtube.com/embed/dQw4w9WgXcQ")
+        expect(recording.formatted_external_media_url).to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
       end
     end
 

--- a/spec/system/cookie_consent_spec.rb
+++ b/spec/system/cookie_consent_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Cookie consent banner" do
+  scenario "displays banner on first visit" do
+    visit root_path
+    expect(page).to have_css(".cookie-consent", visible: :visible)
+    expect(page).to have_text("We use cookies")
+  end
+
+  scenario "hides banner after accepting" do
+    visit root_path
+    within(".cookie-consent") { click_button "Accept All" }
+    expect(page).to have_no_css(".cookie-consent", visible: :visible)
+
+    visit root_path
+    expect(page).to have_css(".cookie-consent[hidden]", visible: :hidden)
+  end
+
+  scenario "hides banner after declining" do
+    visit root_path
+    within(".cookie-consent") { click_button "Necessary Only" }
+    expect(page).to have_no_css(".cookie-consent", visible: :visible)
+
+    visit root_path
+    expect(page).to have_css(".cookie-consent[hidden]", visible: :hidden)
+  end
+
+  scenario "banner has accessible attributes" do
+    visit root_path
+    banner = find(".cookie-consent")
+    expect(banner[:'aria-label']).to eq("Cookie consent")
+    expect(banner[:role]).to eq("dialog")
+  end
+end


### PR DESCRIPTION
Gate Google Analytics behind user consent with a Stimulus-driven cookie consent banner. Analytics loads dynamically only after acceptance. Switch YouTube embeds to youtube-nocookie.com to eliminate third-party tracking cookies.