### PR TITLE
Ignore tom-select 2.6.1 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # 2.6.1 added a focus-stealing guard (fix for Edge autofill issue #806)
+      # that prevents the dropdown from opening under Capybara when another
+      # field already holds focus. Skip 2.6.1; revisit when a later version
+      # lands.
+      - dependency-name: "tom-select"
+        versions: ["2.6.1"]


### PR DESCRIPTION
## Summary
- tom-select 2.6.1 added a focus-stealing guard to fix an Edge autofill loop ([orchidjs/tom-select#806](https://github.com/orchidjs/tom-select/issues/806)). The guard early-returns from `onFocus()` if `document.activeElement` is no longer the tom-select control.
- Under Capybara with headless Chrome, clicking `.ts-control` while another field still holds focus means `onFocus()` is skipped and the dropdown never opens. This deterministically broke the admin song-create system spec (see [PR #419](https://github.com/CircleSongs/CircleSongs/pull/419)).
- Pinning past 2.6.1 — revisit if/when a later version lands.

## Test plan
- [ ] CI passes (dependabot config change only — no code paths affected).
- [ ] After merge, close PR #419 manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)